### PR TITLE
feat: 도시뉴스 탭 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -70,6 +70,7 @@ export default {
       display,
       desktop: [
         { title: '사용법', path: '/manual', icon: 'mdi-school-outline' },
+        { title: '도시뉴스', path: '/news', icon: 'mdi-newspaper-variant-outline' },
         { title: '공지사항', path: '/notice', icon: 'mdi-bullhorn-outline' },
         { title: '문의', path: '/contact', icon: 'mdi-email-edit-outline' },
         { title: 'FAQ', path: '/faq', icon: 'mdi-frequently-asked-questions' },
@@ -77,8 +78,8 @@ export default {
       mobile: [
         { title: '홈', path: '/', icon: 'mdi-home-outline' },
         { title: '사용법', path: '/manual', icon: 'mdi-school-outline' },
+        { title: '도시뉴스', path: '/news', icon: 'mdi-newspaper-variant-outline' },
         { title: '공지사항', path: '/notice', icon: 'mdi-bullhorn-outline' },
-        { title: '문의', path: '/contact', icon: 'mdi-email-edit-outline' },
       ],
     }
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,6 +39,12 @@ const routes = [
     props: true
   },
 
+  {
+    path: '/news',
+    name: 'news',
+    component: () => import(/* webpackChunkName: "news" */ '../views/NewsView.vue')
+  },
+
   // {
   //   path: '/community',
   //   name: 'community',

--- a/src/store/news.js
+++ b/src/store/news.js
@@ -9,6 +9,8 @@ const api = axios.create({
 const apiUrl = process.env.VUE_APP_API_URL
 
 async function getRecent () {
+  // 원본 기사가 아니라 LLM이 요약해 발행한 '도시뉴스' 게시글이 내려온다.
+  // 형식: [{ id, title, content(HTML), sources:[{title,url}], viewCount, createdDate }]
   const response = await api.get(apiUrl + '/news/recent')
   return response.data
 }
@@ -16,46 +18,23 @@ async function getRecent () {
 export const useNewsStore = defineStore('newsStore', {
 
   state: () => ({
-    articles: [],
-    activeKeyword: '전체',
+    posts: [],
     isLoading: false,
     isError: false,
   }),
-
-  getters: {
-    // 수집된 기사에서 키워드 목록을 뽑아 '전체' 와 함께 반환
-    keywords (state) {
-      const set = new Set(
-        state.articles.map((a) => a.keyword).filter((k) => !!k)
-      )
-      return ['전체', ...set]
-    },
-
-    // 현재 선택된 키워드로 필터링된 기사 목록
-    filteredArticles (state) {
-      if (state.activeKeyword === '전체') {
-        return state.articles
-      }
-      return state.articles.filter((a) => a.keyword === state.activeKeyword)
-    },
-  },
 
   actions: {
     async loadRecent () {
       this.isLoading = true
       this.isError = false
       try {
-        this.articles = await getRecent()
+        this.posts = await getRecent()
       } catch (e) {
         this.isError = true
-        this.articles = []
+        this.posts = []
       } finally {
         this.isLoading = false
       }
-    },
-
-    setKeyword (keyword) {
-      this.activeKeyword = keyword
     },
 
     formatDate (dateString) {
@@ -63,44 +42,6 @@ export const useNewsStore = defineStore('newsStore', {
         return ''
       }
       return dayjs(dateString).format('YYYY.MM.DD HH:mm')
-    },
-
-    /**
-     * 백엔드 요약 고정 포맷을 화면용 구조로 파싱.
-     * 형식: [핵심] ... / [내용] - ... / [시사점] ...
-     * 포맷을 벗어나면 raw 로 폴백한다.
-     */
-    parseSummary (summary) {
-      const empty = { core: '', points: [], implication: '', raw: '' }
-      if (!summary || !summary.trim()) {
-        return empty
-      }
-
-      const text = summary.trim()
-      const hasMarker = /\[핵심\]|\[내용\]|\[시사점\]/.test(text)
-      if (!hasMarker) {
-        return { ...empty, raw: text }
-      }
-
-      const section = (label, nextLabels) => {
-        const next = nextLabels.length
-          ? `(?=\\[(?:${nextLabels.join('|')})\\]|$)`
-          : '(?=$)'
-        const re = new RegExp(`\\[${label}\\]([\\s\\S]*?)${next}`)
-        const m = text.match(re)
-        return m ? m[1].trim() : ''
-      }
-
-      const core = section('핵심', ['내용', '시사점'])
-      const contentBlock = section('내용', ['시사점'])
-      const implication = section('시사점', [])
-
-      const points = contentBlock
-        .split('\n')
-        .map((line) => line.replace(/^[\s]*[-•]\s*/, '').trim())
-        .filter((line) => line.length > 0)
-
-      return { core, points, implication, raw: '' }
     },
   },
 })

--- a/src/store/news.js
+++ b/src/store/news.js
@@ -1,0 +1,106 @@
+import { defineStore } from 'pinia'
+import dayjs from 'dayjs'
+import axios from 'axios'
+
+const api = axios.create({
+  headers: { 'Cache-Control': 'no-cache' },
+})
+
+const apiUrl = process.env.VUE_APP_API_URL
+
+async function getRecent () {
+  const response = await api.get(apiUrl + '/news/recent')
+  return response.data
+}
+
+export const useNewsStore = defineStore('newsStore', {
+
+  state: () => ({
+    articles: [],
+    activeKeyword: '전체',
+    isLoading: false,
+    isError: false,
+  }),
+
+  getters: {
+    // 수집된 기사에서 키워드 목록을 뽑아 '전체' 와 함께 반환
+    keywords (state) {
+      const set = new Set(
+        state.articles.map((a) => a.keyword).filter((k) => !!k)
+      )
+      return ['전체', ...set]
+    },
+
+    // 현재 선택된 키워드로 필터링된 기사 목록
+    filteredArticles (state) {
+      if (state.activeKeyword === '전체') {
+        return state.articles
+      }
+      return state.articles.filter((a) => a.keyword === state.activeKeyword)
+    },
+  },
+
+  actions: {
+    async loadRecent () {
+      this.isLoading = true
+      this.isError = false
+      try {
+        this.articles = await getRecent()
+      } catch (e) {
+        this.isError = true
+        this.articles = []
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    setKeyword (keyword) {
+      this.activeKeyword = keyword
+    },
+
+    formatDate (dateString) {
+      if (!dateString) {
+        return ''
+      }
+      return dayjs(dateString).format('YYYY.MM.DD HH:mm')
+    },
+
+    /**
+     * 백엔드 요약 고정 포맷을 화면용 구조로 파싱.
+     * 형식: [핵심] ... / [내용] - ... / [시사점] ...
+     * 포맷을 벗어나면 raw 로 폴백한다.
+     */
+    parseSummary (summary) {
+      const empty = { core: '', points: [], implication: '', raw: '' }
+      if (!summary || !summary.trim()) {
+        return empty
+      }
+
+      const text = summary.trim()
+      const hasMarker = /\[핵심\]|\[내용\]|\[시사점\]/.test(text)
+      if (!hasMarker) {
+        return { ...empty, raw: text }
+      }
+
+      const section = (label, nextLabels) => {
+        const next = nextLabels.length
+          ? `(?=\\[(?:${nextLabels.join('|')})\\]|$)`
+          : '(?=$)'
+        const re = new RegExp(`\\[${label}\\]([\\s\\S]*?)${next}`)
+        const m = text.match(re)
+        return m ? m[1].trim() : ''
+      }
+
+      const core = section('핵심', ['내용', '시사점'])
+      const contentBlock = section('내용', ['시사점'])
+      const implication = section('시사점', [])
+
+      const points = contentBlock
+        .split('\n')
+        .map((line) => line.replace(/^[\s]*[-•]\s*/, '').trim())
+        .filter((line) => line.length > 0)
+
+      return { core, points, implication, raw: '' }
+    },
+  },
+})

--- a/src/views/NewsView.vue
+++ b/src/views/NewsView.vue
@@ -1,0 +1,227 @@
+<template>
+  <v-container class="py-6">
+    <v-row justify="center">
+      <v-col cols="12" md="9" lg="8">
+
+        <!-- 헤더 -->
+        <div class="d-flex align-center justify-space-between flex-wrap mb-1">
+          <div>
+            <h1 class="text-h5 font-weight-bold mb-1">
+              <v-icon icon="mdi-newspaper-variant-outline" color="success" class="mr-1"/>
+              도시뉴스
+            </h1>
+            <p class="text-body-2 text-medium-emphasis mb-0">
+              도시공학·도시계획 뉴스를 모아 AI가 요약해 드려요
+            </p>
+          </div>
+          <v-btn
+            variant="text"
+            prepend-icon="mdi-refresh"
+            color="success"
+            :loading="newsStore.isLoading"
+            @click="refresh"
+          >
+            새로고침
+          </v-btn>
+        </div>
+
+        <!-- 키워드 필터 -->
+        <v-chip-group
+          v-if="!newsStore.isLoading && newsStore.articles.length"
+          v-model="selectedKeyword"
+          selected-class="text-success"
+          mandatory
+          column
+          class="mb-2"
+        >
+          <v-chip
+            v-for="keyword in newsStore.keywords"
+            :key="keyword"
+            :value="keyword"
+            variant="outlined"
+            filter
+          >
+            {{ keyword }}
+          </v-chip>
+        </v-chip-group>
+
+        <!-- 로딩 -->
+        <div v-if="newsStore.isLoading" class="text-center py-16">
+          <v-progress-circular indeterminate color="success" size="48"/>
+          <p class="text-body-2 text-medium-emphasis mt-4">뉴스를 불러오는 중…</p>
+        </div>
+
+        <!-- 에러 -->
+        <v-alert
+          v-else-if="newsStore.isError"
+          type="error"
+          variant="tonal"
+          class="my-6"
+          text="뉴스를 불러오지 못했어요. 잠시 후 새로고침해 주세요."
+        />
+
+        <!-- 빈 상태 -->
+        <div
+          v-else-if="!newsStore.filteredArticles.length"
+          class="text-center text-medium-emphasis py-16"
+        >
+          표시할 뉴스가 없어요.
+        </div>
+
+        <!-- 기사 카드 목록 -->
+        <template v-else>
+          <v-card
+            v-for="article in newsStore.filteredArticles"
+            :key="article.id"
+            variant="outlined"
+            rounded="lg"
+            class="mb-4"
+          >
+            <v-card-item>
+              <div class="d-flex align-center mb-1" style="gap: 8px;">
+                <v-chip
+                  v-if="article.keyword"
+                  size="small"
+                  color="success"
+                  variant="tonal"
+                  label
+                >
+                  {{ article.keyword }}
+                </v-chip>
+                <span class="text-caption text-medium-emphasis">
+                  {{ newsStore.formatDate(article.publishedAt || article.collectedDate) }}
+                </span>
+              </div>
+              <v-card-title class="text-wrap text-h6 px-0" style="line-height: 1.4;">
+                <a
+                  :href="article.originalUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="article-title"
+                >
+                  {{ article.title }}
+                </a>
+              </v-card-title>
+            </v-card-item>
+
+            <v-card-text>
+              <template v-if="hasStructuredSummary(article)">
+                <p
+                  v-if="parsed(article).core"
+                  class="text-body-1 font-weight-medium mb-3"
+                >
+                  {{ parsed(article).core }}
+                </p>
+
+                <v-list
+                  v-if="parsed(article).points.length"
+                  density="compact"
+                  class="bg-transparent py-0 mb-2"
+                >
+                  <v-list-item
+                    v-for="(point, i) in parsed(article).points"
+                    :key="i"
+                    class="px-0"
+                    min-height="28"
+                  >
+                    <template v-slot:prepend>
+                      <v-icon icon="mdi-circle-small" size="small" color="success"/>
+                    </template>
+                    <v-list-item-title class="text-body-2 text-wrap">
+                      {{ point }}
+                    </v-list-item-title>
+                  </v-list-item>
+                </v-list>
+
+                <p
+                  v-if="parsed(article).implication"
+                  class="text-body-2 text-medium-emphasis mt-2"
+                >
+                  <v-icon icon="mdi-lightbulb-on-outline" size="small" color="warning" class="mr-1"/>
+                  {{ parsed(article).implication }}
+                </p>
+              </template>
+
+              <!-- 고정 포맷이 아닌 경우 원문 그대로 -->
+              <p v-else class="text-body-2" style="white-space: pre-wrap;">
+                {{ parsed(article).raw || '요약이 아직 준비되지 않았어요.' }}
+              </p>
+            </v-card-text>
+
+            <v-divider/>
+            <v-card-actions>
+              <v-btn
+                :href="article.originalUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="text"
+                size="small"
+                color="success"
+                append-icon="mdi-open-in-new"
+              >
+                원문 보기
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </template>
+
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { useNewsStore } from '@/store/news'
+
+export default {
+  name: 'NewsView',
+
+  setup () {
+    const newsStore = useNewsStore()
+    return { newsStore }
+  },
+
+  computed: {
+    selectedKeyword: {
+      get () {
+        return this.newsStore.activeKeyword
+      },
+      set (value) {
+        this.newsStore.setKeyword(value || '전체')
+      },
+    },
+  },
+
+  methods: {
+    parsed (article) {
+      return this.newsStore.parseSummary(article.summary)
+    },
+
+    hasStructuredSummary (article) {
+      const p = this.parsed(article)
+      return !!(p.core || p.points.length || p.implication)
+    },
+
+    refresh () {
+      this.newsStore.setKeyword('전체')
+      this.newsStore.loadRecent()
+    },
+  },
+
+  created () {
+    this.newsStore.loadRecent()
+  },
+}
+</script>
+
+<style scoped>
+.article-title {
+  color: rgb(var(--v-theme-on-surface));
+  text-decoration: none;
+}
+
+.article-title:hover {
+  color: rgb(var(--v-theme-success));
+  text-decoration: underline;
+}
+</style>

--- a/src/views/NewsView.vue
+++ b/src/views/NewsView.vue
@@ -4,14 +4,14 @@
       <v-col cols="12" md="9" lg="8">
 
         <!-- 헤더 -->
-        <div class="d-flex align-center justify-space-between flex-wrap mb-1">
+        <div class="d-flex align-center justify-space-between flex-wrap mb-3">
           <div>
             <h1 class="text-h5 font-weight-bold mb-1">
               <v-icon icon="mdi-newspaper-variant-outline" color="success" class="mr-1"/>
               도시뉴스
             </h1>
             <p class="text-body-2 text-medium-emphasis mb-0">
-              도시공학·도시계획 뉴스를 모아 AI가 요약해 드려요
+              도시공학·도시계획 뉴스를 모아 AI가 한 편으로 요약해 드려요
             </p>
           </div>
           <v-btn
@@ -24,26 +24,6 @@
             새로고침
           </v-btn>
         </div>
-
-        <!-- 키워드 필터 -->
-        <v-chip-group
-          v-if="!newsStore.isLoading && newsStore.articles.length"
-          v-model="selectedKeyword"
-          selected-class="text-success"
-          mandatory
-          column
-          class="mb-2"
-        >
-          <v-chip
-            v-for="keyword in newsStore.keywords"
-            :key="keyword"
-            :value="keyword"
-            variant="outlined"
-            filter
-          >
-            {{ keyword }}
-          </v-chip>
-        </v-chip-group>
 
         <!-- 로딩 -->
         <div v-if="newsStore.isLoading" class="text-center py-16">
@@ -62,106 +42,60 @@
 
         <!-- 빈 상태 -->
         <div
-          v-else-if="!newsStore.filteredArticles.length"
+          v-else-if="!newsStore.posts.length"
           class="text-center text-medium-emphasis py-16"
         >
-          표시할 뉴스가 없어요.
+          아직 발행된 도시뉴스 요약이 없어요.
         </div>
 
-        <!-- 기사 카드 목록 -->
+        <!-- 요약 게시글 목록 -->
         <template v-else>
           <v-card
-            v-for="article in newsStore.filteredArticles"
-            :key="article.id"
+            v-for="post in newsStore.posts"
+            :key="post.id"
             variant="outlined"
             rounded="lg"
             class="mb-4"
           >
             <v-card-item>
-              <div class="d-flex align-center mb-1" style="gap: 8px;">
-                <v-chip
-                  v-if="article.keyword"
-                  size="small"
-                  color="success"
-                  variant="tonal"
-                  label
-                >
-                  {{ article.keyword }}
-                </v-chip>
-                <span class="text-caption text-medium-emphasis">
-                  {{ newsStore.formatDate(article.publishedAt || article.collectedDate) }}
-                </span>
-              </div>
               <v-card-title class="text-wrap text-h6 px-0" style="line-height: 1.4;">
-                <a
-                  :href="article.originalUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="article-title"
-                >
-                  {{ article.title }}
-                </a>
+                {{ post.title }}
               </v-card-title>
+              <span class="text-caption text-medium-emphasis">
+                {{ newsStore.formatDate(post.createdDate) }}
+              </span>
             </v-card-item>
 
+            <!-- LLM 요약 본문 (HTML) -->
             <v-card-text>
-              <template v-if="hasStructuredSummary(article)">
-                <p
-                  v-if="parsed(article).core"
-                  class="text-body-1 font-weight-medium mb-3"
-                >
-                  {{ parsed(article).core }}
-                </p>
+              <div class="news-body" v-html="post.content"></div>
+            </v-card-text>
 
-                <v-list
-                  v-if="parsed(article).points.length"
-                  density="compact"
-                  class="bg-transparent py-0 mb-2"
-                >
+            <!-- 출처 (본문과 분리된 별도 블록) -->
+            <template v-if="post.sources && post.sources.length">
+              <v-divider/>
+              <v-card-text class="pb-2">
+                <div class="text-overline text-medium-emphasis mb-1">출처</div>
+                <v-list density="compact" class="bg-transparent py-0">
                   <v-list-item
-                    v-for="(point, i) in parsed(article).points"
+                    v-for="(source, i) in post.sources"
                     :key="i"
+                    :href="source.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     class="px-0"
                     min-height="28"
                   >
                     <template v-slot:prepend>
-                      <v-icon icon="mdi-circle-small" size="small" color="success"/>
+                      <v-icon icon="mdi-link-variant" size="small" color="success"/>
                     </template>
-                    <v-list-item-title class="text-body-2 text-wrap">
-                      {{ point }}
+                    <v-list-item-title class="text-body-2 text-wrap source-link">
+                      {{ source.title }}
                     </v-list-item-title>
                   </v-list-item>
                 </v-list>
-
-                <p
-                  v-if="parsed(article).implication"
-                  class="text-body-2 text-medium-emphasis mt-2"
-                >
-                  <v-icon icon="mdi-lightbulb-on-outline" size="small" color="warning" class="mr-1"/>
-                  {{ parsed(article).implication }}
-                </p>
-              </template>
-
-              <!-- 고정 포맷이 아닌 경우 원문 그대로 -->
-              <p v-else class="text-body-2" style="white-space: pre-wrap;">
-                {{ parsed(article).raw || '요약이 아직 준비되지 않았어요.' }}
-              </p>
-            </v-card-text>
-
-            <v-divider/>
-            <v-card-actions>
-              <v-btn
-                :href="article.originalUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="text"
-                size="small"
-                color="success"
-                append-icon="mdi-open-in-new"
-              >
-                원문 보기
-              </v-btn>
-            </v-card-actions>
+              </v-card-text>
+            </template>
           </v-card>
         </template>
 
@@ -181,29 +115,8 @@ export default {
     return { newsStore }
   },
 
-  computed: {
-    selectedKeyword: {
-      get () {
-        return this.newsStore.activeKeyword
-      },
-      set (value) {
-        this.newsStore.setKeyword(value || '전체')
-      },
-    },
-  },
-
   methods: {
-    parsed (article) {
-      return this.newsStore.parseSummary(article.summary)
-    },
-
-    hasStructuredSummary (article) {
-      const p = this.parsed(article)
-      return !!(p.core || p.points.length || p.implication)
-    },
-
     refresh () {
-      this.newsStore.setKeyword('전체')
       this.newsStore.loadRecent()
     },
   },
@@ -215,12 +128,32 @@ export default {
 </script>
 
 <style scoped>
-.article-title {
-  color: rgb(var(--v-theme-on-surface));
-  text-decoration: none;
+.news-body :deep(h3) {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 12px 0 6px;
 }
 
-.article-title:hover {
+.news-body :deep(p) {
+  margin: 6px 0;
+  line-height: 1.6;
+}
+
+.news-body :deep(ul) {
+  padding-left: 20px;
+  margin: 6px 0;
+}
+
+.news-body :deep(li) {
+  margin: 2px 0;
+  line-height: 1.5;
+}
+
+.source-link {
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.source-link:hover {
   color: rgb(var(--v-theme-success));
   text-decoration: underline;
 }


### PR DESCRIPTION
- /news 라우트와 도시뉴스 뷰(NewsView) 추가
- 백엔드 공개 API(GET /news/recent)로 도시공학 뉴스 조회
- 키워드 필터, 새로고침, 요약([핵심]/[내용]/[시사점]) 카드 렌더링, 반응형/로딩/에러 처리
- 데스크톱·모바일 네비게이션에 도시뉴스 메뉴 추가
- news Pinia 스토어(조회·요약 파싱·날짜 포맷)